### PR TITLE
Relax a bit safety constraints, make it build with newer Servants

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+
+allow-newer:
+  *:base

--- a/example/calc.hs
+++ b/example/calc.hs
@@ -212,13 +212,13 @@ serveAsyncCalcAPI env
   :<|> \sumA prodA pureA -> wrap (ioPolynomial env sumA prodA pureA)
 
   where
-    wrap :: (FromJSON i, ToJSON i) => ((Value -> IO ()) -> i -> IO Int) -> Maybe Delay
+    wrap :: (FromJSON i, ToJSON i, MimeRender JSON i) => ((Value -> IO ()) -> i -> IO Int) -> Maybe Delay
          -> Server (AsyncJobsAPI Value i Int)
     wrap f delayA =
       let wraplog log i = waitDelay delayA >> logConsole i >> log i in
       simpleServeJobsAPI (jobEnv env) (simpleJobFunction (\i log -> f (wraplog log) i))
 
-runClientCallbackIO :: (ToJSON error, ToJSON event, ToJSON input, ToJSON output)
+runClientCallbackIO :: (ToJSON error, ToJSON event, ToJSON input, ToJSON output, MimeRender JSON event, MimeRender JSON error, MimeRender JSON output)
                     => ClientEnv -> URL
                     -> ChanMessage error event input output
                     -> IO ()
@@ -272,7 +272,7 @@ type TestAPI
               :> ReqBody '[JSON, FormUrlEncoded] Any
               :> Post '[JSON] ()
   :<|> "pull" :> Get '[JSON] [([T.Text], Any)]
-  :<|> "clear" :> PostNoContent '[JSON] ()
+  :<|> "clear" :> Post '[JSON] ()
 
 serveTestAPI :: Env -> Server TestAPI
 serveTestAPI env

--- a/example/scrapy-orch.hs
+++ b/example/scrapy-orch.hs
@@ -78,6 +78,9 @@ data ScraperInput = ScraperInput
 
 makeLenses ''ScraperInput
 
+instance ToJSON ScraperInput where
+  toJSON = genericToJSON $ jsonOptions "_scin_"
+
 instance FromJSON ScraperInput where
   parseJSON = genericParseJSON $ jsonOptions "_scin_"
 

--- a/servant-job.cabal
+++ b/servant-job.cabal
@@ -53,11 +53,11 @@ library
     , monad-control
     , mtl
     , scientific
-    , servant >=0.16
-    , servant-client >=0.16
-    , servant-client-core >=0.16
+    , servant >=0.18.2 && < 0.22
+    , servant-client >=0.18.2 && < 0.22
+    , servant-client-core >=0.18.2 && < 0.22
     , servant-flatten
-    , servant-server >=0.16
+    , servant-server >=0.18.2 && < 0.22
     , servant-swagger >=1.1.5
     , split
     , swagger2

--- a/src/Servant/Job/Async.hs
+++ b/src/Servant/Job/Async.hs
@@ -149,6 +149,9 @@ type MonadAsyncJobs env err event output m =
   , ToJSON event
   , ToJSON output
   , ToJSON err
+  , MimeRender JSON output
+  , MimeRender JSON err
+  , MimeRender JSON event
   )
 
 type MonadAsyncJobs' callbacks env err event output m =
@@ -208,7 +211,12 @@ simpleJobFunction :: (input -> (event -> IO ()) -> IO output)
 simpleJobFunction f = JobFunction (\i log -> liftBase (f i log))
 
 newJob :: forall callbacks env err event input output m
-        . MonadAsyncJobs' callbacks env err event output m
+        . ( MonadAsyncJobs' callbacks env err event output m
+          , MimeRender JSON event
+          , MimeRender JSON input
+          , MimeRender JSON output
+          , MimeRender JSON err
+          )
        => JobFunction env err event input output
        -> JobInput callbacks input -> m (JobStatus 'Safe event)
 newJob task i = do
@@ -220,8 +228,8 @@ newJob task i = do
     postCallback m =
       forM_ (i ^. job_callback) $ \url ->
         liftBase (C.runClientM (clientMCallback m)
-                (C.ClientEnv (jenv ^. jenv_manager)
-                             (url ^. base_url) Nothing))
+                (C.mkClientEnv (jenv ^. jenv_manager)
+                             (url ^. base_url)))
 
     pushLog :: MVar [event] -> event -> IO ()
     pushLog m e = do
@@ -328,7 +336,7 @@ serveJobAPI jid'
     wrap' g limit offset = wrap (g limit offset)
 
 serveJobsAPI :: forall callbacks env err m event input output ctI ctO
-              . MonadAsyncJobs' callbacks env err event output m
+              . (MonadAsyncJobs' callbacks env err event output m, MimeRender JSON input)
              => JobFunction env err event input output
              -> AsyncJobsServerT' ctI ctO callbacks event input output m
 serveJobsAPI f
@@ -344,6 +352,9 @@ simpleServeJobsAPI :: forall event input output.
                       ( FromJSON input
                       , ToJSON   event
                       , ToJSON   output
+                      , MimeRender JSON input
+                      , MimeRender JSON output
+                      , MimeRender JSON event
                       )
                    => JobEnv event output
                    -> SimpleJobFunction event input output

--- a/src/Servant/Job/Async.hs
+++ b/src/Servant/Job/Async.hs
@@ -19,7 +19,10 @@ module Servant.Job.Async
   , AsyncJobAPI'
   , AsyncJobsAPI
   , AsyncJobsAPI'
+  , AsyncJobServerT
   , AsyncJobsServer
+  , AsyncJobsServerT
+  , AsyncJobsServerT'
   , MonadAsyncJobs
   , MonadAsyncJobs'
 
@@ -28,6 +31,7 @@ module Servant.Job.Async
   , job_id
   , job_log
   , job_status
+  , jobStatus
 
   , JobInput(JobInput)
   , job_input
@@ -69,7 +73,7 @@ module Servant.Job.Async
   , Safety(..)
 
   -- Internals
-  , Job
+  , Job(..)
   , job_async
   , deleteJob
   , checkID

--- a/src/Servant/Job/Client.hs
+++ b/src/Servant/Job/Client.hs
@@ -130,7 +130,7 @@ type CallJobC event input output =
   )
 
 class Monad m => MonadJob m where
-  callJob :: CallJobC event input output
+  callJob :: (CallJobC event input output, MimeRender JSON input)
           => JobServerURL event input output -> input -> m output
 
 data ClientJobError
@@ -189,7 +189,7 @@ progress event = do
 runClientJob :: M m => URL -> (ClientError -> ClientJobError) -> C.ClientM a -> m a
 runClientJob url err m = do
   env <- ask
-  let cenv = C.ClientEnv (env ^. cenv_manager) (url ^. base_url) Nothing
+  let cenv = C.mkClientEnv (env ^. cenv_manager) (url ^. base_url)
   liftBase (C.runClientM m cenv)
     >>= either (throwError . err) pure
 
@@ -197,7 +197,7 @@ runClientJobStreaming :: (M m, NFData a) => URL -> (ClientError -> ClientJobErro
                       -> SC.ClientM a -> m a
 runClientJobStreaming url err m = do
   env <- ask
-  let cenv = SC.ClientEnv (env ^. cenv_manager) (url ^. base_url) Nothing
+  let cenv = SC.mkClientEnv (env ^. cenv_manager) (url ^. base_url)
   liftBase (SC.runClientM m cenv)
     >>= either (throwError . err) pure
 
@@ -211,13 +211,13 @@ onRunningJob job f = do
 forgetRunningJob :: RunningJob event input output -> RunningJob event' input' output'
 forgetRunningJob (PrivateRunningJob u a i) = PrivateRunningJob u a i
 
-clientSyncJob :: (ToJSON input, ToJSON event, FromJSON event, FromJSON output, M m)
+clientSyncJob :: (ToJSON input, ToJSON event, FromJSON event, FromJSON output, M m, MimeRender JSON input)
               => JobServerURL event input output -> input -> m (JobOutput output)
 clientSyncJob jurl =
   runClientJob (jurl ^. job_server_url) StartingJobError .
     C.client (proxySyncJobsAPI jurl)
 
-clientStreamJob :: (CallJobC event input output, M m)
+clientStreamJob :: (CallJobC event input output, M m, MimeRender JSON input)
                 => JobServerURL event input output -> input -> m (JobOutput output)
 clientStreamJob jurl input = do
   LogEvent log_event <- view cenv_log_event
@@ -284,7 +284,13 @@ clientCallbackJob :: (ToJSON input, ToJSON event, FromJSON event, FromJSON outpu
 clientCallbackJob jurl input =
   clientCallbackJob' jurl $ C.client (callbackJobsAPI jurl) . CallbackInput input
 
-clientMCallback :: (ToJSON error, ToJSON event, ToJSON output)
+clientMCallback :: (ToJSON error
+                   , ToJSON event
+                   , ToJSON output
+                   , MimeRender JSON event
+                   , MimeRender JSON error
+                   , MimeRender JSON output
+                   )
                 => ChanMessage error event input output -> C.ClientM ()
 clientMCallback msg = do
   forM_ (msg ^. msg_event)  cli_event
@@ -294,7 +300,14 @@ clientMCallback msg = do
     (cli_event :<|> cli_error :<|> cli_result) =
         C.client (Proxy :: Proxy (CallbackAPI error event output))
 
-clientCallback :: (ToJSON error, ToJSON event, ToJSON output, M m)
+clientCallback :: (ToJSON error
+                  , ToJSON event
+                  , ToJSON output
+                  , M m
+                  , MimeRender JSON event
+                   , MimeRender JSON error
+                   , MimeRender JSON output
+                  )
                => URL -> ChanMessage error event input output -> m ()
 clientCallback cb_url = runClientJob cb_url CallbackError . clientMCallback
 
@@ -378,7 +391,7 @@ clientAsyncJob jurl i = do
   onRunningJob job Set.delete
   pure out
 
-callJobM :: (CallJobC event input output, M m)
+callJobM :: (CallJobC event input output, M m, MimeRender JSON input)
          => JobServerURL event input output -> input -> m output
 callJobM jurl input = do
   progress $ NewTask jurl

--- a/src/Servant/Job/Core.hs
+++ b/src/Servant/Job/Core.hs
@@ -185,10 +185,10 @@ newID :: KnownSymbol k => Proxy k -> SecretKey -> UTCTime -> Int -> ID 'Safe k
 newID p s t n = PrivateID tn n t $ macID tn s t n
   where tn = symbolVal p
 
-mkID :: KnownSymbol k => Proxy k -> Int -> UTCTime -> String -> ID 'Unsafe k
+mkID :: KnownSymbol k => Proxy k -> Int -> UTCTime -> String -> ID safety k
 mkID p n t d = PrivateID (symbolVal p) n t d
 
-instance (KnownSymbol k, safety ~ 'Unsafe) => FromHttpApiData (ID safety k) where
+instance (KnownSymbol k{- , safety ~ 'Unsafe -}) => FromHttpApiData (ID safety k) where
   parseUrlPiece s =
     case T.splitOn "-" s of
       [n, t, d] -> mkID (Proxy :: Proxy k)
@@ -203,7 +203,7 @@ instance {-safety ~ 'Safe =>-} ToHttpApiData (ID safety k) where
                       , toUrlPiece (utcTimeToPOSIXSeconds (j ^. id_time))
                       , toUrlPiece (j ^. id_token)]
 
-instance (KnownSymbol k, safety ~ 'Unsafe) => FromJSON (ID safety k) where
+instance (KnownSymbol k{-, safety ~ 'Unsafe -}) => FromJSON (ID safety k) where
   parseJSON s = either (fail . T.unpack) pure . parseUrlPiece =<< parseJSON s
 
 instance {-safety ~ 'Safe =>-} ToJSON (ID safety k) where

--- a/src/Servant/Job/Core.hs
+++ b/src/Servant/Job/Core.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE TypeFamilies #-}
 module Servant.Job.Core
   -- Essentials
-  ( ID
+  ( ID(..)
   , id_type
   , id_number
   , id_time
@@ -51,12 +51,14 @@ module Servant.Job.Core
 
   -- Internals
   , checkID
+  , macID
   , newItem
   , getItem
   , deleteItem
   , isValidItem
   , forgetID
   , mkID
+  , newID
   , defaultDuration
   )
   where

--- a/src/Servant/Job/Types.hs
+++ b/src/Servant/Job/Types.hs
@@ -255,10 +255,10 @@ type AsyncJobsServer event input output = AsyncJobsServerT event input output Ha
 
 makeLenses ''JobStatus
 
-instance (safety ~ 'Safe, ToJSON event) => ToJSON (JobStatus safety event) where
+instance ({- safety ~ 'Safe, -}ToJSON event) => ToJSON (JobStatus safety event) where
   toJSON = genericToJSON $ jsonOptions "_job_"
 
-instance (safety ~ 'Unsafe, FromJSON event) => FromJSON (JobStatus safety event) where
+instance ({- safety ~ 'Unsafe, -}FromJSON event) => FromJSON (JobStatus safety event) where
   parseJSON = genericParseJSON $ jsonOptions "_job_"
 
 instance (Typeable safety, Typeable event, ToSchema event) => ToSchema (JobStatus safety event) where


### PR DESCRIPTION
Hello @np , long time no chat.

As you know this library it's still heavily used in `gargantext`, and over the years we accumulated a bit of cruft by having all sort of forks, namely from Alexandre and Alp. This PR is an effort in trying to take the most "important" commits of the last few years and submitting them as part of a PR, so that we can rely on the upstream package rather than the fork.

In particular, this PR does a few things:

1. Adds a `cabal.project` (but I can remove that, if you don't fancy it);
2. It adds a bunch of `MimeRender` constraints, which are a necessary evil in [modern versions of Servant](https://github.com/haskell-servant/servant/issues/1367);
3. It relax a bit certain safety constraints in some functions, as those were too stringent, in particular when using Servant's newest [named routes](https://gitlab.iscpif.fr/gargantext/haskell-gargantext/merge_requests/289) , which Gargantext is moving towards.

Let me know what you think. Thank you!